### PR TITLE
gpu loading, device selection

### DIFF
--- a/logic/bot_logic.py
+++ b/logic/bot_logic.py
@@ -15,7 +15,7 @@ import torch
 load_dotenv()
 
 
-device = "cuda:0" if torch.cuda.is_available() else "cpu"
+device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 MODEL_NAME = os.environ.get("MODEL_NAME", "")
 MAX_HISTORY_LENGTH=os.environ.get("HISTORY_LENGTH", 5)
@@ -23,8 +23,8 @@ MAX_HISTORY_LENGTH=os.environ.get("HISTORY_LENGTH", 5)
 model = None
 
 if MODEL_NAME:
-    print(f"loading {MODEL_NAME} on local, please wait...")
-    model = GPTNeoForCausalLM.from_pretrained(MODEL_NAME)
+    print(f"loading {MODEL_NAME} on local, on device {device}, please wait...")
+    model = GPTNeoForCausalLM.from_pretrained(MODEL_NAME).to(device)
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
 else:
     print(f"no model name found - please check your .env file, gonna try to use nlpcloud.io")


### PR DESCRIPTION
ensure that the model is loaded only to gpu (or cpu) device. before it was loading only to cpu and when torch was available,  it was giving an error, "the tensor was loaded on two different devices".